### PR TITLE
feat: static report landing page provides context

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,33 @@
-# Pinning Service Compliance
+# Pinning Service Compliance Reports
 
-## What is Pinning Service Compliance?
+## Latest repots
 
-It’s a test suite to help our pinning service providers, and ipfs implementers who use those providers, see which services are correctly implementing the pinning services spec. Our primary goal is to ensure that all of the pinning service providers are consistent, so that implementers can depend on the functionality they expect.
-
-The Pinning Service Compliance project originated from https://github.com/ipfs/pinning-services-api-spec/issues/64, so you can read more details and discussion there.
-
-## Latest static reports
+Periodically tested:
 
 * [Estuary](./api.estuary.tech.md)
 * [Pinata](./api.pinata.cloud.md)
 * [web3.storage](./api.web3.storage.md)
 * [nft.storage](./nft.storage.md)
 
-## Run the compliance checker against a different service
+Want to add your service to the list? [Open an issue](https://github.com/ipfs-shipyard/pinning-service-compliance/issues/new).
+
+
+## About 
+
+### What is Pinning Service Compliance?
+
+It’s a test suite to help our pinning service providers, and IPFS implementers who use those providers, see which services are correctly implementing the [IPFS Pinning Service API Spec](https://ipfs.github.io/pinning-services-api-spec/).  Our primary goal is to ensure that all of the pinning service providers are consistent, and users can depend on the functionality they expect.
+
+The Pinning Service Compliance project originated from [pinning-services-api-spec/issues/64](https://github.com/ipfs/pinning-services-api-spec/issues/64).
+
+### How to run the compliance checker against my own pinning service?
+
+[pinning-service-compliance](https://www.npmjs.com/package/@ipfs-shipyard/pinning-service-compliance) package is available on NPM:
 
 ```bash
 npx -p @ipfs-shipyard/pinning-service-compliance -- pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
 ```
+
+### Bugs? Suggestions?
+
+Sources and issues: [ipfs-shipyard/pinning-service-compliance](https://github.com/ipfs-shipyard/pinning-service-compliance)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,20 @@
 # Pinning Service Compliance
 
-## Results
+## What is Pinning Service Compliance?
+
+It’s a test suite to help our pinning service providers, and ipfs implementers who use those providers, see which services are correctly implementing the pinning services spec. Our primary goal is to ensure that all of the pinning service providers are consistent, so that implementers can depend on the functionality they expect.
+
+The Pinning Service Compliance project originated from https://github.com/ipfs/pinning-services-api-spec/issues/64, so you can read more details and discussion there.
+
+## Latest static reports
 
 * [Estuary](./api.estuary.tech.md)
 * [Pinata](./api.pinata.cloud.md)
 * [web3.storage](./api.web3.storage.md)
 * [nft.storage](./nft.storage.md)
+
+## Run the compliance checker against a different service
+
+```bash
+npx -p @ipfs-shipyard/pinning-service-compliance -- pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
+```


### PR DESCRIPTION
From lidel regarding feedback on draft for #24 :

> (1) https://ipfs-shipyard.github.io/pinning-service-compliance/ does not immediately explain itself. People should learn about [pinning service api spec](https://ipfs.github.io/pinning-services-api-spec/), that [compliance CLI tool for it exists on NPM](https://www.npmjs.com/package/@ipfs-shipyard/pinning-service-compliance), and how to run it on their own. Mind adding [this context ](https://github.com/ipfs-shipyard/pinning-service-compliance/blob/ff48f3b4b2d77d6fd95590b87e692b1095e689cd/README.md?plain=1#L3-L11)to the header of the page and your explainer "What is Pinning Service Compliance” from the email draft?