### PR TITLE
fix: npx usage succeeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Run the compliance checker against a service:
 
 ```bash
-npx -p @ipfs-shipyard/pinning-service-compliance -- pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
+npx @ipfs-shipyard/pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
 ```
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Periodically tested:
 Want to add your service to the list? [Open an issue](https://github.com/ipfs-shipyard/pinning-service-compliance/issues/new).
 
 
-## About 
+## About
 
 ### What is Pinning Service Compliance?
 
@@ -25,7 +25,7 @@ The Pinning Service Compliance project originated from [pinning-services-api-spe
 [pinning-service-compliance](https://www.npmjs.com/package/@ipfs-shipyard/pinning-service-compliance) package is available on NPM:
 
 ```bash
-npx -p @ipfs-shipyard/pinning-service-compliance -- pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
+npx @ipfs-shipyard/pinning-service-compliance -s <pinning_service_endpoint> <auth_token>
 ```
 
 ### Bugs? Suggestions?

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "bin": {
-    "@ipfs-shipyard/pinning-service-compliance": "./dist/src/index.js"
-  },
+  "bin": "./dist/src/index.js",
   "type": "module",
   "eslintConfig": {
     "extends": "ipfs"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-esm
+#!/usr/bin/env node
 import { writeSync } from 'fs'
 import process from 'node:process'
 


### PR DESCRIPTION
npx usage seemed to be broken, but I was able to test that these changes work by both:

### Running npx on current package:
```
npx . -s $ESTUARY_API_ENDPOINT $ESTUARY_API_TOKEN
```

### Running npx on `npm pack`ed package:

```bash
npm pack
npx ipfs-shipyard-pinning-service-compliance-1.0.5.tgz -s $ESTUARY_API_ENDPOINT $ESTUARY_API_TOKEN
```