### PR TITLE
fix: expect 401 for unauthorized responses

### DIFF
--- a/src/checks/auth/checkEmptyBearerToken.ts
+++ b/src/checks/auth/checkEmptyBearerToken.ts
@@ -13,8 +13,8 @@ const checkEmptyBearerToken = async (pair: ServiceAndTokenPair) => {
   })
 
   apiCall.expect({
-    title: 'Returns a 403',
-    fn: async ({ details }) => details.response.status === 403
+    title: 'Returns a 401',
+    fn: async ({ details }) => details.response.status === 401
   })
 
   await apiCall.runExpectations()

--- a/src/checks/auth/checkEmptyBearerToken.ts
+++ b/src/checks/auth/checkEmptyBearerToken.ts
@@ -1,6 +1,7 @@
 import { getJoiSchema } from '../../utils/getJoiSchema.js'
 import { ApiCall } from '../../ApiCall.js'
 import type { ServiceAndTokenPair } from '../../types.js'
+import { responseCode } from '../../expectations/index.js'
 
 const checkEmptyBearerToken = async (pair: ServiceAndTokenPair) => {
   const schema = await getJoiSchema('Failure')
@@ -12,10 +13,7 @@ const checkEmptyBearerToken = async (pair: ServiceAndTokenPair) => {
     title: 'Request with no authentication token'
   })
 
-  apiCall.expect({
-    title: 'Returns a 401',
-    fn: async ({ details }) => details.response.status === 401
-  })
+  apiCall.expect(responseCode(401))
 
   await apiCall.runExpectations()
 }

--- a/src/checks/auth/checkInvalidBearerToken.ts
+++ b/src/checks/auth/checkInvalidBearerToken.ts
@@ -1,6 +1,7 @@
 import { getJoiSchema } from '../../utils/getJoiSchema.js'
 import { ApiCall } from '../../ApiCall.js'
 import type { ServiceAndTokenPair } from '../../types.js'
+import { responseCode } from '../../expectations/index.js'
 
 const checkInvalidBearerToken = async (pair: ServiceAndTokenPair) => {
   const schema = await getJoiSchema('Failure')
@@ -11,10 +12,7 @@ const checkInvalidBearerToken = async (pair: ServiceAndTokenPair) => {
     schema,
     title: 'Request with invalid token'
   })
-    .expect({
-      title: 'Returns a 401',
-      fn: async ({ details }) => details.response.status === 401
-    })
+    .expect(responseCode(401))
     .runExpectations()
 }
 

--- a/src/checks/auth/checkInvalidBearerToken.ts
+++ b/src/checks/auth/checkInvalidBearerToken.ts
@@ -12,8 +12,8 @@ const checkInvalidBearerToken = async (pair: ServiceAndTokenPair) => {
     title: 'Request with invalid token'
   })
     .expect({
-      title: 'Returns a 403',
-      fn: async ({ details }) => details.response.status === 403
+      title: 'Returns a 401',
+      fn: async ({ details }) => details.response.status === 401
     })
     .runExpectations()
 }


### PR DESCRIPTION
The specification says unauthorized requests should return a 401. 401 is more correct than 403. see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses