### PR TITLE
Add Filebase to the PSA compliance checker

### DIFF
--- a/.github/workflows/build-reports.yml
+++ b/.github/workflows/build-reports.yml
@@ -60,6 +60,27 @@ jobs:
           name: estuary-report
           path: docs/api.estuary.tech.md
 
+  check-filebase-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - uses: ipfs/aegir/actions/cache-node-modules@master
+      - name: Reports Cache
+        uses: actions/cache@v3
+        with:
+          path: docs
+          key: ${{ github.sha }}-filebase
+      - run: npm run dev-start -- -s ${{ secrets.FILEBASE_API_ENDPOINT }} ${{secrets.FILEBASE_API_TOKEN}}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: filebase-logs
+          path: docs/api.filebase.io
+      - uses: actions/upload-artifact@v2
+        with:
+          name: filebase-report
+          path: docs/api.filebase.io.md
+
   check-nft-dot-storage-compliance:
     runs-on: ubuntu-latest
     steps:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 Periodically tested:
 
 * [Estuary](./api.estuary.tech.md)
+* [Filebase](./api.filebase.io.md)
 * [Pinata](./api.pinata.cloud.md)
 * [web3.storage](./api.web3.storage.md)
 * [nft.storage](./nft.storage.md)
@@ -22,7 +23,7 @@ The Pinning Service Compliance project originated from [pinning-services-api-spe
 
 ### How to run the compliance checker against my own pinning service?
 
-***Disclaimer***: It is recommended to use an `auth_token` separate from your production/live services. The compliance checks will do their best not to corrupt any existing pins you have, but consistent tests without consistent data is challenging. 
+***Disclaimer***: It is recommended to use an `auth_token` separate from your production/live services. The compliance checks will do their best not to corrupt any existing pins you have, but consistent tests without consistent data is challenging.
 
 [pinning-service-compliance](https://www.npmjs.com/package/@ipfs-shipyard/pinning-service-compliance) package is available on NPM:
 


### PR DESCRIPTION
Hi there,

We would like to add Filebase to the IPFS PSA compliance checker. The following `SECRETS` can be used:
- `FILEBASE_API_ENDPOINT`: `https://api.filebase.io/v1/ipfs`
- `FILEBASE_API_TOKEN`: Sign up for a free account at https://filebase.com and follow https://docs.filebase.com/storage-networks/ipfs/ipfs-pinning#re-pinning-existing-ipfs-cids-with-filebase-using-the-ipfs-cli to generate a token. We are also happy to provide a token out of band as well if needed.
