### PR TITLE
Check requestids rather than cids for pagination

### DIFF
--- a/src/checks/get/testPagination.ts
+++ b/src/checks/get/testPagination.ts
@@ -79,7 +79,7 @@ const testPagination = async (pair: ServiceAndTokenPair) => {
       fn: ({ result }) => result?.results.size === 10
     })
 
-  const cids: Set<string> = new Set()
+  const requestIds: Set<string> = new Set()
   const firstPageResult = await firstPageOfPins.request
   let before = new Date()
   let firstPageSize = 0
@@ -91,7 +91,7 @@ const testPagination = async (pair: ServiceAndTokenPair) => {
   } else {
     before = getOldestPinCreateDate(firstPageResult.results)
     firstPageResult.results.forEach((pin) => {
-      cids.add(pin.pin.cid)
+      requestIds.add(pin.requestid)
     })
     firstPageSize = firstPageResult.results.size
   }
@@ -112,9 +112,9 @@ const testPagination = async (pair: ServiceAndTokenPair) => {
           const secondPageSize = secondPageResult.results.size
 
           secondPageResult.results.forEach((pin) => {
-            cids.add(pin.pin.cid)
+            requestIds.add(pin.requestid)
           })
-          return firstPageSize + secondPageSize === cids.size
+          return firstPageSize + secondPageSize === requestIds.size
         } else {
           throw new Error('Second page result is null')
         }


### PR DESCRIPTION
## Problem
The pagination check `The next page of pins doesn't contain any of previous pages pins` relies on counting unique `cids` to assert if a request appears on 2 different pages. 
However, the spec allows for multiple Pin Requests to target the same `cid`, so the check might fail, if 2 requests with the same id exists, despite the pagination actually working as expected.

## The fix
Instead of counting unique `cids` we should count unique `requestid`s