### PR TITLE
fix(ci): pin node version

### DIFF
--- a/.github/workflows/build-reports.yml
+++ b/.github/workflows/build-reports.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -44,6 +48,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -65,6 +73,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -86,6 +98,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -107,6 +123,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -128,6 +148,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -149,6 +173,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3
@@ -170,6 +198,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3

--- a/.github/workflows/check-compliance.yml
+++ b/.github/workflows/check-compliance.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - uses: ipfs/aegir/actions/cache-node-modules@master
       - name: Reports Cache
         uses: actions/cache@v3


### PR DESCRIPTION
CI is broken, seems the last version that worked was 18, but it was not hardcoded everywhere, let's see if this helps