### PR TITLE
fix: use AbortSignal.timeout instead of setTimeout

### DIFF
--- a/src/clientFromServiceAndTokenPair.ts
+++ b/src/clientFromServiceAndTokenPair.ts
@@ -9,12 +9,9 @@ function clientFromServiceAndTokenPair ([endpointUrl, accessToken]: ServiceAndTo
     endpointUrl,
     accessToken,
     fetchApi: async (url: RequestInfo | URL, init?: RequestInit) => {
-      const abortController = new AbortController()
-      const { signal } = abortController
-      setTimeout(() => { abortController.abort() }, 60000)
       return fetch(url, {
         ...init,
-        signal: init?.signal ?? signal
+        signal: init?.signal ?? AbortSignal.timeout(60000)
       })
     },
     middleware: [


### PR DESCRIPTION
The timeouts returned from `setTimeout` keep the node process running until they fire.

Swap for `AbortSignal.timeout` which works the same way but doesn't keep the event loop from exiting.